### PR TITLE
新規登録画面のロール選択ページの修正、テーブルの表示修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -73,3 +73,13 @@ h3 {
     position: relative;
     bottom: -200px;
 }
+
+.planner {
+    position: relative;
+    right: 70px;
+}
+
+.customer {
+    position: relative;
+    left: 50px;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -62,9 +62,10 @@ h3 {
 }
 
 .table{
-    width: 100%;
+    width: 60%;
     table-layout: fixed;
     margin-bottom: 1px;
+    margin: 0 auto;
 
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -67,3 +67,8 @@ h3 {
     margin-bottom: 1px;
 
 }
+
+.role {
+    position: relative;
+    bottom: -200px;
+}

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -14,7 +14,7 @@ class ReservationsController < ApplicationController
   end
 
   def update
-    @reservation = current_user.reservations.find(params[:id])
+    @reservation = Reservation.find_by(id: params[:id])
 
     if !customer_reserved? && right_customer?
       @reservation.update_attribute(:customer_id, nil)

--- a/app/views/static_pages/choose.html.slim
+++ b/app/views/static_pages/choose.html.slim
@@ -2,6 +2,7 @@
     h1
       | どちらで新規アカウントを作成しますか？
 
-    = link_to "フィナンシャルプランナー 新規", new_planner_url, { class: "btn-outline-secondary" }
-    = link_to "お客様 新規", new_customer_url, { class: "btn-outline-secondary" }
+    .role
+      = link_to "フィナンシャルプランナー 新規", new_planner_url, { class: "btn btn-primary btn-lg" }
+      = link_to "お客様 新規", new_customer_url, { class: "btn btn-info btn-lg" }
 

--- a/app/views/static_pages/choose.html.slim
+++ b/app/views/static_pages/choose.html.slim
@@ -3,6 +3,6 @@
       | どちらで新規アカウントを作成しますか？
 
     .role
-      = link_to "フィナンシャルプランナー 新規", new_planner_url, { class: "btn btn-primary btn-lg" }
-      = link_to "お客様 新規", new_customer_url, { class: "btn btn-info btn-lg" }
+      = link_to "フィナンシャルプランナー 新規", new_planner_url, { class: "btn btn-primary btn-lg planner" }
+      = link_to "お客様 新規", new_customer_url, { class: "btn btn-info btn-lg customer" }
 


### PR DESCRIPTION
新規登録画面のロール選択ページの修正
<img width="1680" alt="スクリーンショット 2021-03-03 11 06 32" src="https://user-images.githubusercontent.com/51792327/109741516-8fdedb00-7c10-11eb-91c4-99bb1f23b072.png">
テーブルの表示修正
<img width="1680" alt="スクリーンショット 2021-03-03 11 19 22" src="https://user-images.githubusercontent.com/51792327/109742417-54dda700-7c12-11eb-8cdb-f6e6860786bd.png">

reservationコントローラのupdate修正

- updateはカスタマーしか使わない。customer_idはnilの場合もあるので、current_user起点ではデータを持って来れない